### PR TITLE
Add .gz support and increase file size limit to 300 MB

### DIFF
--- a/reveal/src/main/kotlin/com/amazon/macie/samples/reveal/Reveal.kt
+++ b/reveal/src/main/kotlin/com/amazon/macie/samples/reveal/Reveal.kt
@@ -140,7 +140,7 @@ class Reveal(private val aws: AwsDependencies = object : AwsDependencies {}) : R
         /**
          * The biggest object we'll fetch from S3.
          */
-        private const val MAX_SIZE = 10 * 1024 * 1024
+        private const val MAX_SIZE = 300 * 1024 * 1024
 
         /**
          * The JSONPath configuration used to extract locators.

--- a/reveal/src/main/kotlin/com/amazon/macie/samples/reveal/locators/GzipRecordLocator.kt
+++ b/reveal/src/main/kotlin/com/amazon/macie/samples/reveal/locators/GzipRecordLocator.kt
@@ -1,0 +1,30 @@
+// locators/GzipRecordLocator.kt
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+package com.amazon.macie.samples.reveal.locators
+
+import com.amazon.macie.samples.reveal.RevealQuery
+import mu.KotlinLogging
+import software.amazon.awssdk.services.macie2.model.Occurrences
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
+
+object GzipRecordLocator : Locator {
+    private val logger = KotlinLogging.logger {}
+
+    override fun locate(
+        content: ByteArray,
+        occurrences: Map<String, Occurrences>,
+        query: RevealQuery
+    ): Map<String, List<String>> {
+        require(occurrences.values.stream().anyMatch { it.hasRecords() }) { "Internal: invalid locator picked" }
+
+        val gzipInputStream = GZIPInputStream(ByteArrayInputStream(content))
+        val uncompressedContent = gzipInputStream.readBytes()
+
+        // Delegate the processing to another locator based on the content's structure
+        // For example, you could delegate to the JsonRecordLocator if you know the GZIP content is JSON
+        return JsonRecordLocator.locate(uncompressedContent, occurrences, query)
+    }
+}

--- a/reveal/src/main/kotlin/com/amazon/macie/samples/reveal/locators/LocatorRegistry.kt
+++ b/reveal/src/main/kotlin/com/amazon/macie/samples/reveal/locators/LocatorRegistry.kt
@@ -14,6 +14,7 @@ object LocatorRegistry {
         "text/csv" to CsvRecordLocator,
         "application/parquet" to ParquetRecordLocator,
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" to XLSRecordLocator,
+        "application/gzip" to GzipRecordLocator,
     )
 
     fun getLocatorForMime(mime: String): Locator? {


### PR DESCRIPTION
[US1147208](https://rally1.rallydev.com/#/?detail=/userstory/718638087469&fdp=true): AWS Macie -  Reveal Samples: enable in devqa using command line utility

1. Add support for .gz files so that we can reveal findings for our txn and classic-txn data
2. Increase file size limit from 10 MB to 300 MB